### PR TITLE
adapt package.json based on other test-editor projects

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,16 +1,42 @@
 {
   "name": "@testeditor/testeditor-commons",
   "version": "0.1.1",
+  "description": "Angular library containing generic components used throughout the Test-Editor.",
   "license": "EPL",
+  "keywords": [
+    "test-editor",
+    "angular",
+    "common",
+    "widgets"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/test-editor/web-testeditor-commons"
+  },
+  "contributors": [
+    "Jan Jelschen",
+    "Gunther Bachmann"
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
+  "engines": {
+    "node": ">= 6.9.0",
+    "npm": ">= 3.0.0"
+  },
   "scripts": {
+    "clean": "rimraf out-tsc dist/*",
+    "prebuild": "npm run clean",
     "ng": "ng",
     "start": "ng serve",
     "build": "ng build --prod",
     "test": "ng test",
     "test:once": "ng test --single-run",
     "lint": "ng lint",
+    "pree2e": "webdriver-manager update --ignore_ssl --gecko=false",
     "e2e": "ng e2e",
-    "packagr": "ng-packagr -p ng-package.json"
+    "packagr": "ng-packagr -p ng-package.json",
+    "postversion": "git push && git push --tags"
   },
   "peerDependencies": {
     "@angular/animations": "^5.2.0",


### PR DESCRIPTION
… still couldn't publish, probably because
```
"publishConfig": {
    "access": "public"
}
```
was missing.

So now I just copied all settings that were still missing in this project over from web-testexec-navigator's package.json file.