### PR TITLE
configure ng-packagr to not delete dist dir

### DIFF
--- a/ng-package.json
+++ b/ng-package.json
@@ -1,5 +1,6 @@
 {
   "$schema": "./node_modules/ng-packagr/ng-package.schema.json",
+  "deleteDestPath": false,
   "lib": {
     "entryFile": "public_api.ts"
   }


### PR DESCRIPTION
When this project is linked (`yarn link`) during development, and an Angular app is being run using `ng serve`, live reload will fail to recompile when this project is re-packaged, because ng-packagr will, by default, delete the dist directory. With this change, the directory will not be explicitly deleted.