### PR TITLE
Feature/top level css classes

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -18,3 +18,4 @@
   </li>
 </ul>
 
+<app-tree-viewer [model]="model" [level]="0" [config]="treeConfig"></app-tree-viewer>

--- a/src/app/app.component.spec.ts
+++ b/src/app/app.component.spec.ts
@@ -1,8 +1,10 @@
 import { TestBed, async } from '@angular/core/testing';
 import { AppComponent } from './app.component';
+import { TreeViewerModule } from './modules/widgets/tree-viewer/tree-viewer.module';
 describe('AppComponent', () => {
   beforeEach(async(() => {
     TestBed.configureTestingModule({
+      imports: [ TreeViewerModule ],
       declarations: [
         AppComponent
       ],

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -27,6 +27,6 @@ export class AppComponent {
   treeConfig: TreeViewerConfig = {
     onDoubleClick: (node: TreeNode) => node.expanded = !node.expanded,
     onIconClick: (node: TreeNode) => node.expanded = !node.expanded,
-    onClick: () => {}
+    onClick: (node: TreeNode) => node.cssClasses = 'hidden'
   };
 }

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1,4 +1,6 @@
 import { Component } from '@angular/core';
+import { TreeNode } from './modules/widgets/tree-viewer/tree-node';
+import { TreeViewerConfig } from './modules/widgets/tree-viewer/tree-viewer-config';
 
 @Component({
   selector: 'app-root',
@@ -7,4 +9,24 @@ import { Component } from '@angular/core';
 })
 export class AppComponent {
   title = 'app';
+
+  model: TreeNode = {
+    name: 'parent node',
+    collapsedCssClasses: 'fa-chevron-right',
+    expandedCssClasses: 'fa-chevron-down',
+    leafCssClasses: 'fa-folder',
+    cssClasses: '',
+    expanded: false,
+    children: [
+      { name: 'child node 1', children: [] },
+      { name: 'child node 2', children: [] },
+      { name: 'child node 3', children: [] }
+    ]
+  };
+
+  treeConfig: TreeViewerConfig = {
+    onDoubleClick: (node: TreeNode) => node.expanded = !node.expanded,
+    onIconClick: (node: TreeNode) => node.expanded = !node.expanded,
+    onClick: () => {}
+  };
 }

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -3,6 +3,7 @@ import { NgModule } from '@angular/core';
 
 
 import { AppComponent } from './app.component';
+import { TreeViewerModule } from './modules/widgets/tree-viewer/tree-viewer.module';
 
 
 @NgModule({
@@ -10,7 +11,7 @@ import { AppComponent } from './app.component';
     AppComponent
   ],
   imports: [
-    BrowserModule
+    BrowserModule, TreeViewerModule
   ],
   providers: [],
   bootstrap: [AppComponent]

--- a/src/app/modules/widgets/tree-viewer/tree-node.ts
+++ b/src/app/modules/widgets/tree-viewer/tree-node.ts
@@ -7,6 +7,7 @@ export interface TreeNode {
   expandedCssClasses?: string;
   collapsedCssClasses?: string;
   leafCssClasses?: string;
+  cssClasses?: string;
   hover?: string;
   id?: string;
 }

--- a/src/app/modules/widgets/tree-viewer/tree-viewer.component.html
+++ b/src/app/modules/widgets/tree-viewer/tree-viewer.component.html
@@ -1,4 +1,4 @@
-<div class="tree-view" *ngIf="model">
+<div class="tree-view" *ngIf="model" [ngClass]="cssClasses">
   <div class="tree-view-item">
     <div
       class="tree-view-item-key"

--- a/src/app/modules/widgets/tree-viewer/tree-viewer.component.spec.ts
+++ b/src/app/modules/widgets/tree-viewer/tree-viewer.component.spec.ts
@@ -13,7 +13,8 @@ describe('TreeViewerComponent', () => {
   const singleEmptyTreeNode: () => TreeNode = () => ({
     name: 'tree node',
     children: [],
-    leafCssClasses: 'fa-file'
+    leafCssClasses: 'fa-file',
+    cssClasses: 'someCssClass otherCssClass'
   });
 
   const treeNodeWithSubNodes: () => TreeNode = () => ({
@@ -245,6 +246,37 @@ describe('TreeViewerComponent', () => {
 
     // then
     expect(generalClickHandlerTriggered).toBeTruthy('the general click handler was not triggered.');
+  });
+
+  it('uses model`s css classes for node', () => {
+    // given
+    const treeNode = singleEmptyTreeNode();
+    component.model = treeNode;
+
+    // when
+    fixture.detectChanges();
+
+    // then
+    const treeView = fixture.debugElement.query(By.css('.tree-view'));
+    expect(treeView.classes['someCssClass']).toBeTruthy();
+    expect(treeView.classes['otherCssClass']).toBeTruthy();
+  });
+
+  it('uses applies css classes when the model changes', () => {
+    // given
+    const treeNode = singleEmptyTreeNode();
+    component.model = treeNode;
+    fixture.detectChanges();
+
+    // when
+    component.model.cssClasses = 'newCssClass';
+    fixture.detectChanges();
+
+    // then
+    const treeView = fixture.debugElement.query(By.css('.tree-view'));
+    expect(treeView.classes['someCssClass']).toBeFalsy();
+    expect(treeView.classes['otherCssClass']).toBeFalsy();
+    expect(treeView.classes['newCssClass']).toBeTruthy();
   });
 
 });

--- a/src/app/modules/widgets/tree-viewer/tree-viewer.component.ts
+++ b/src/app/modules/widgets/tree-viewer/tree-viewer.component.ts
@@ -18,6 +18,10 @@ export class TreeViewerComponent implements OnInit {
   ngOnInit() {
   }
 
+  get cssClasses(): string {
+    return this.model.cssClasses ? this.model.cssClasses : '';
+  }
+
   get icon(): string {
     if (this.model) {
       switch (this.model.expanded) {

--- a/src/styles.css
+++ b/src/styles.css
@@ -1,1 +1,4 @@
 /* You can add global styles to this file, and also import other style files */
+.hidden {
+  display: none;
+}


### PR DESCRIPTION
It is now possible to add css classes to the top-level `div` element corresponding to a tree node (with children), using the model's `cssClasses` property. I refrained from renaming the other *cssClasses fields, which actually only apply to the node's icon, because its public api…
The demo app contains a tree view, whose items get the 'hidden' css class on click, which makes them disappear, as expected.