### PR TITLE
remove marker field from TreeNode

### DIFF
--- a/src/app/modules/widgets/tree-viewer/indicator-box/indicator-box.component.spec.ts
+++ b/src/app/modules/widgets/tree-viewer/indicator-box/indicator-box.component.spec.ts
@@ -10,14 +10,18 @@ describe('IndicatorBoxComponent', () => {
   let hostComponent: TestHostComponent;
   let fixture: ComponentFixture<TestHostComponent>;
 
+  interface TreeNodeWithMarker extends TreeNode {
+    marker?: any;
+  }
+
   const sampleMarkerStates: MarkerState[] = [{
-      condition: (node) => node.marker.sampleField && node.marker.otherField === 'test',
+      condition: (node: TreeNodeWithMarker) => node.marker.sampleField && node.marker.otherField === 'test',
       cssClasses: 'someClass',
-      label: (node) => `sampleField = ${node.marker.sampleField}`,
+      label: (node: TreeNodeWithMarker) => `sampleField = ${node.marker.sampleField}`,
     }, {
-      condition: (node) => !node.marker.sampleField,
+      condition: (node: TreeNodeWithMarker) => !node.marker.sampleField,
       cssClasses: 'otherClass',
-      label: (node) => `otherField = ${node.marker.otherField}`,
+      label: (node: TreeNodeWithMarker) => `otherField = ${node.marker.otherField}`,
   }];
 
   @Component({
@@ -28,7 +32,7 @@ describe('IndicatorBoxComponent', () => {
     @ViewChild(IndicatorBoxComponent)
     public indicatorBoxComponentUnderTest: IndicatorBoxComponent;
 
-    node: TreeNode;
+    node: TreeNodeWithMarker;
     states: MarkerState[];
   }
 
@@ -105,7 +109,7 @@ describe('IndicatorBoxComponent', () => {
     hostComponent.node = {children: [], name: 'sampleNode', root: null, marker: marker };
     hostComponent.states = sampleMarkerStates.slice(0);
     hostComponent.states.unshift({
-      condition: (node) => node.marker.nonExisting.property === true,
+      condition: (node: TreeNodeWithMarker) => node.marker.nonExisting.property === true,
       cssClasses: 'brokenStateClass',
       label: () => { throw new Error('broken label provider'); },
     });
@@ -126,7 +130,7 @@ describe('IndicatorBoxComponent', () => {
     hostComponent.node = {children: [], name: 'sampleNode', root: null, marker: marker };
     hostComponent.states = sampleMarkerStates.slice(0);
     hostComponent.states.unshift({
-      condition: (node) => node.marker.nonExisting.property === true,
+      condition: (node: TreeNodeWithMarker) => node.marker.nonExisting.property === true,
       cssClasses: 'brokenStateClass',
       label: () => { throw new Error('broken label provider'); },
     });

--- a/src/app/modules/widgets/tree-viewer/markers/field.spec.ts
+++ b/src/app/modules/widgets/tree-viewer/markers/field.spec.ts
@@ -6,13 +6,13 @@ describe('Field', () => {
     const testField: Field = {
       condition: (element) => element != null,
       states: [{
-        condition: (node) => node.marker.someAttribute,
-        cssClasses: 'someClass',
-        label: () => 'some',
+        condition: (node) => node.root === null,
+        cssClasses: 'rootCssClass',
+        label: () => 'I am root!',
       }, {
-        condition: (node) => !node.marker.someAttribute,
-        cssClasses: 'otherClass',
-        label: () => 'other',
+        condition: (node) => node.root !== null,
+        cssClasses: 'treeCssClass',
+        label: () => 'I am not root.',
       }]
     };
     expect(testField).toBeTruthy();

--- a/src/app/modules/widgets/tree-viewer/markers/marker.state.spec.ts
+++ b/src/app/modules/widgets/tree-viewer/markers/marker.state.spec.ts
@@ -4,11 +4,11 @@ import { TreeNode } from '../tree-node';
 describe('MarkerState', () => {
 
   let sampleMarkerState: MarkerState;
-  const sampleAttributeValue = 42;
+  const sampleName = 'sampleName';
 
   beforeEach(() => {
     sampleMarkerState = {
-      condition: (node) => node.marker.someAttribute === sampleAttributeValue,
+      condition: (node) => node.name === sampleName,
       cssClasses: 'someCssClass',
       label: () => 'The label',
     };
@@ -16,7 +16,7 @@ describe('MarkerState', () => {
 
   it('conditions can be invoked', () => {
     // given
-    const node: TreeNode = { name: '', children: [], root: null, marker: { someAttribute: sampleAttributeValue } };
+    const node: TreeNode = { name: sampleName, children: [], root: null };
 
     // when
     const actualResult = sampleMarkerState.condition(node);
@@ -32,12 +32,12 @@ describe('MarkerState', () => {
       cssClasses: '',
       label: (node_) => `label for ${node_.name}`,
     };
-    const node: TreeNode = { name: 'the node', children: [], root: null, marker: { someAttribute: sampleAttributeValue } };
+    const node: TreeNode = { name: sampleName, children: [], root: null };
 
     // when
     const actualLabel = markerState.label(node);
 
     // then
-    expect(actualLabel).toEqual('label for the node');
+    expect(actualLabel).toEqual('label for sampleName');
   });
 });

--- a/src/app/modules/widgets/tree-viewer/tree-node.ts
+++ b/src/app/modules/widgets/tree-viewer/tree-node.ts
@@ -11,7 +11,6 @@ export interface TreeNode {
   cssClasses?: string;
   hover?: string;
   id?: string;
-  marker?: any;
 }
 
 


### PR DESCRIPTION
A generic `marker` field on `TreeNode` is not really necessary. API users can simply extend `TreeNode` and add application-specific fields as needed. All interactions with these fields is handed in from the outside using appropriate closures.

This is also nicer for overall type-safety.