### PR TITLE
move http provider service into commons

### DIFF
--- a/src/app/modules/event-types-in.ts
+++ b/src/app/modules/event-types-in.ts
@@ -20,3 +20,5 @@ export interface TreeViewerInputBoxConfig extends InputBoxConfig {
   iconCssClasses: string;
 }
 export const TREE_NODE_CREATE_AT_SELECTED = 'treenode.create-at-selected';
+
+export const HTTP_CLIENT_SUPPLIED = 'httpClient.supplied';

--- a/src/app/modules/event-types-out.ts
+++ b/src/app/modules/event-types-out.ts
@@ -3,3 +3,5 @@
 // payload { node: TreeNode, root: TreeNode }
 export const TREE_NODE_SELECTED = 'treenode.selected';
 export const TREE_NODE_DESELECTED = 'treenode.deselected';
+
+export const HTTP_CLIENT_NEEDED = 'httpClient.needed';

--- a/src/app/modules/services/http-provider-service/http-provider.service.spec.ts
+++ b/src/app/modules/services/http-provider-service/http-provider.service.spec.ts
@@ -1,0 +1,64 @@
+import { TestBed, inject, fakeAsync } from '@angular/core/testing';
+
+import { HttpProviderService } from './http-provider.service';
+import { MessagingService, MessagingModule } from '@testeditor/messaging-service';
+import { HttpClient, HttpClientModule } from '@angular/common/http';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+
+describe('HttpProviderService', () => {
+  let messagingService: MessagingService;
+  let httpClient: HttpClient;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [
+        HttpClientTestingModule,
+        HttpClientModule,
+        MessagingModule.forRoot()
+      ],
+      providers: [HttpProviderService]
+    });
+    messagingService = TestBed.get(MessagingService);
+    httpClient = TestBed.get(HttpClient);
+
+    const subscription = messagingService.subscribe('httpClient.needed', () => {
+      subscription.unsubscribe();
+      messagingService.publish('httpClient.supplied', { httpClient: httpClient });
+    });
+  });
+
+  it('should be created', inject([HttpProviderService], (service: HttpProviderService) => {
+    expect(service).toBeTruthy();
+  }));
+
+  it('should return http client', fakeAsync(inject([HttpProviderService], (serviceUnderTest: HttpProviderService) => {
+    // when
+    const httpPromise = serviceUnderTest.getHttpClient();
+
+    // then
+    httpPromise.then((actualClient) => {
+      expect(actualClient).toEqual(httpClient);
+    });
+  })));
+
+  it('should use cached value', fakeAsync(inject([HttpProviderService], (serviceUnderTest: HttpProviderService) => {
+    // given
+    serviceUnderTest.getHttpClient().then(() => {
+      let calledSecondTime = false;
+      const subscription = messagingService.subscribe('httpClient.needed', () => {
+        subscription.unsubscribe();
+        calledSecondTime = true;
+        messagingService.publish('httpClient.supplied', { httpClient: httpClient });
+      });
+
+      // when
+      const secondHttpPromise = serviceUnderTest.getHttpClient();
+
+      // then
+      expect(calledSecondTime).toBeFalsy();
+      secondHttpPromise.then((actualClient) => {
+        expect(actualClient).toEqual(httpClient);
+      });
+    });
+  })));
+});

--- a/src/app/modules/services/http-provider-service/http-provider.service.ts
+++ b/src/app/modules/services/http-provider-service/http-provider.service.ts
@@ -1,0 +1,36 @@
+import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { MessagingService } from '@testeditor/messaging-service';
+import { HTTP_CLIENT_SUPPLIED } from '../../event-types-in';
+import { HTTP_CLIENT_NEEDED } from '../../event-types-out';
+import { Observable } from 'rxjs/Observable';
+import 'rxjs/add/observable/bindCallback';
+
+@Injectable()
+export class HttpProviderService {
+
+  private httpClientPromise: Promise<HttpClient>;
+  private httpClient: HttpClient;
+
+  constructor(private messagingService: MessagingService) {
+    const getObservable = Observable.bindCallback(this.retrieveHttpClient, (client: HttpClient) => client);
+    this.httpClientPromise = getObservable(this.messagingService).toPromise();
+  }
+
+  async getHttpClient(): Promise<HttpClient> {
+    if (!this.httpClient) {
+        this.messagingService.publish(HTTP_CLIENT_NEEDED, null);
+        this.httpClient = await this.httpClientPromise;
+    }
+
+    return this.httpClient;
+  }
+
+  private retrieveHttpClient(messagingService: MessagingService, callback: (client: HttpClient) => void): void {
+    const responseSubscription = messagingService.subscribe(HTTP_CLIENT_SUPPLIED, (httpClientPayload) => {
+      responseSubscription.unsubscribe();
+      callback(httpClientPayload.httpClient);
+    });
+  }
+
+}


### PR DESCRIPTION
Our `HttpProviderService` is unnecessarily duplicated over multiple projects right now. I made one more copy – into the commons project here – so that we can then remove it from all other projects, and reference this instance, instead.