### PR TITLE
do not cache scroll container

### DIFF
--- a/src/app/modules/widgets/tree-viewer/tree-viewer-scrolling.component.spec.ts
+++ b/src/app/modules/widgets/tree-viewer/tree-viewer-scrolling.component.spec.ts
@@ -62,47 +62,52 @@ describe('tree viewer inside scrollable viewport', () => {
 
   it('detects that root element is initially fully visible', () => {
     // given
-    scrollContainer.scrollTop = 0;
+    const scrollableParent = treeViewer.findScrollableParent();
+
     // when
-    const actualResult = treeViewer.isFullyVisible();
+    scrollContainer.scrollTop = 0;
 
     // then
-    expect(actualResult).toBeTruthy();
+    expect(treeViewer.extendsAboveViewport(scrollableParent)).toBeFalsy();
+    expect(treeViewer.extendsBelowViewport(scrollableParent)).toBeFalsy();
   });
 
   it('detects that root element is not fully visible after scrolling down', () => {
     // given
-    scrollContainer.scrollTop = 1;
+    const scrollableParent = treeViewer.findScrollableParent();
 
     // when
-    const actualResult = treeViewer.isFullyVisible();
+    scrollContainer.scrollTop = 1;
 
     // then
-    expect(actualResult).toBeFalsy();
+    expect(treeViewer.extendsAboveViewport(scrollableParent)).toBeTruthy();
+    expect(treeViewer.extendsBelowViewport(scrollableParent)).toBeFalsy();
   });
 
   it('detects that child element is initially not fully visible', () => {
     // given
-    scrollContainer.scrollTop = 0;
+    const scrollableParent = treeViewer.findScrollableParent();
     const childComponent: TreeViewerComponent = fixture.debugElement.query(By.css('div:nth-child(11) > app-tree-viewer')).componentInstance;
 
     // when
-    const actualResult = childComponent.isFullyVisible();
+    scrollContainer.scrollTop = 0;
 
     // then
-    expect(actualResult).toBeFalsy();
+    expect(childComponent.extendsAboveViewport(scrollableParent)).toBeFalsy();
+    expect(childComponent.extendsBelowViewport(scrollableParent)).toBeTruthy();
   });
 
   it('detects that child element becomes fully visible after scrolling down', () => {
     // given
-    scrollContainer.scrollTop = 200;
+    const scrollableParent = treeViewer.findScrollableParent();
     const childComponent: TreeViewerComponent = fixture.debugElement.query(By.css('div:nth-child(11) > app-tree-viewer')).componentInstance;
 
     // when
-    const actualResult = childComponent.isFullyVisible();
+    scrollContainer.scrollTop = 200;
 
     // then
-    expect(actualResult).toBeTruthy();
+    expect(childComponent.extendsAboveViewport(scrollableParent)).toBeFalsy();
+    expect(childComponent.extendsBelowViewport(scrollableParent)).toBeFalsy();
   });
 
   it('scrolls down to selected element below the viewport', (done: any) => {

--- a/src/app/modules/widgets/tree-viewer/tree-viewer.component.ts
+++ b/src/app/modules/widgets/tree-viewer/tree-viewer.component.ts
@@ -20,7 +20,6 @@ export class TreeViewerComponent implements OnInit, OnChanges, NodeView {
   private static readonly NO_SCROLLABLE_PARENT = {};
 
   @ViewChild('treeViewItemKey') treeViewItemKey: ElementRef;
-  private _scrollableParent: any = null;
 
   @Input() model: TreeNode;
   @Input() level = 0;
@@ -97,45 +96,40 @@ export class TreeViewerComponent implements OnInit, OnChanges, NodeView {
   }
 
   public scrollIntoView() {
-    if (this.treeViewItemKey && this.hasScrollContainer()) {
-      if (this.extendsBelowViewport()) {
-        this.treeViewItemKey.nativeElement.scrollIntoView({behavior: 'smooth', block: 'end', inline: 'nearest'});
-      } else if (this.extendsAboveViewport()) {
-        this.treeViewItemKey.nativeElement.scrollIntoView({behavior: 'smooth', block: 'start', inline: 'nearest'});
+    if (this.treeViewItemKey) {
+      const scrollableParent = this.findScrollableParent();
+      if (this.hasScrollContainer(scrollableParent)) {
+        if (this.extendsBelowViewport(scrollableParent)) {
+          this.treeViewItemKey.nativeElement.scrollIntoView({behavior: 'smooth', block: 'end', inline: 'nearest'});
+        } else if (this.extendsAboveViewport(scrollableParent)) {
+          this.treeViewItemKey.nativeElement.scrollIntoView({behavior: 'smooth', block: 'start', inline: 'nearest'});
+        }
       }
     }
   }
 
-  public isFullyVisible(): boolean {
-    return !this.extendsAboveViewport() && !this.extendsBelowViewport();
+  private hasScrollContainer(scrollableParent: any): boolean {
+    return scrollableParent !== TreeViewerComponent.NO_SCROLLABLE_PARENT;
   }
 
-  public hasScrollContainer(): boolean {
-    return this.scrollableParent !== TreeViewerComponent.NO_SCROLLABLE_PARENT;
-  }
-
-  private extendsBelowViewport(): boolean {
+  public extendsBelowViewport(scrollableParent: any): boolean {
     const elementPosition = this.treeViewItemKey.nativeElement.getBoundingClientRect();
-    const containerPosition = this.scrollableParent.getBoundingClientRect();
+    const containerPosition = scrollableParent.getBoundingClientRect();
 
     return elementPosition.bottom > containerPosition.bottom;
   }
 
-  private extendsAboveViewport(): boolean {
+  public extendsAboveViewport(scrollableParent: any): boolean {
     const elementPosition = this.treeViewItemKey.nativeElement.getBoundingClientRect();
-    const containerPosition = this.scrollableParent.getBoundingClientRect();
+    const containerPosition = scrollableParent.getBoundingClientRect();
 
     return  elementPosition.top < containerPosition.top;
   }
 
-  private get scrollableParent(): any {
-    if (this._scrollableParent === null) {
-      this._scrollableParent = this.findScrollableParent(this.treeViewItemKey.nativeElement);
+  public findScrollableParent(element?: any): any {
+    if (!element) {
+      element = this.treeViewItemKey.nativeElement;
     }
-    return this._scrollableParent;
-  }
-
-  private findScrollableParent(element: any): any {
     const parent = element.parentNode;
     if (!parent) {
       return TreeViewerComponent.NO_SCROLLABLE_PARENT;


### PR DESCRIPTION
if there is enough space initially to show all tree elements,
the scroll container cannot be identified and a dummy is put
into the cache instead. When the screen space is reduced or the
tree grows (e.g. by expanding composite nodes) scrolling becomes
necessary, but won't work properly with the dummy container.